### PR TITLE
Use sassc-rails instead of sass-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Icon web font for Rails (used in pplog.net) https://taea.github.io/inuicon/demo.
 
 ```ruby
 # Assets
-gem 'sass-rails'
 gem 'inuicon-rails'
 ```
 

--- a/inuicon-rails.gemspec
+++ b/inuicon-rails.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = InuiconRails::VERSION
 
-  gem.add_dependency "sass-rails"
+  gem.add_dependency "sassc-rails"
 end


### PR DESCRIPTION
> [Ruby Sass End-of-Life: 26 March 2019 · Issue #420 · rails/sass-rails](https://github.com/rails/sass-rails/issues/420)

